### PR TITLE
feat: added null-handling functionality to numeric type.

### DIFF
--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -180,13 +180,13 @@ class NumericType(BaseType):
 
     @type_operator(FIELD_NUMERIC)
     def less_than(self, other_numeric):
-        if not self.exists(): 
+        if self.exists(): 
             return (other_numeric - self.value) > self.EPSILON 
         return False
 
     @type_operator(FIELD_NUMERIC)
     def less_than_or_equal_to(self, other_numeric):
-        if not self.exists(): 
+        if self.exists(): 
             return self.less_than(other_numeric) or self.equal_to(other_numeric)
         return False 
     

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -156,43 +156,43 @@ class NumericType(BaseType):
 
     @type_operator(FIELD_NUMERIC)
     def equal_to(self, other_numeric):
-        if self.exists(): 
-            return abs(self.value - other_numeric) <= self.EPSILON
-        return False 
-
+        if self.does_not_exist(): 
+            return False 
+        return abs(self.value - other_numeric) <= self.EPSILON
+       
     @type_operator(FIELD_NUMERIC)
     def not_equal_to(self, other_numeric):
-        if self.exists(): 
-            return abs(self.value - other_numeric) > self.EPSILON
-        return False
+        if self.does_not_exist(): 
+            return False 
+        return abs(self.value - other_numeric) > self.EPSILON
 
     @type_operator(FIELD_NUMERIC)
     def greater_than(self, other_numeric):
-        if self.exists(): 
-            return (self.value - other_numeric) > self.EPSILON 
-        return False
+        if self.does_not_exist(): 
+            return False 
+        return (self.value - other_numeric) > self.EPSILON 
 
     @type_operator(FIELD_NUMERIC)
     def greater_than_or_equal_to(self, other_numeric):
-        if self.exists(): 
-            return self.greater_than(other_numeric) or self.equal_to(other_numeric) 
-        return False 
+        if self.does_not_exist():  
+            return False 
+        return self.greater_than(other_numeric) or self.equal_to(other_numeric)
 
     @type_operator(FIELD_NUMERIC)
     def less_than(self, other_numeric):
-        if self.exists(): 
-            return (other_numeric - self.value) > self.EPSILON 
-        return False
-
+        if self.does_not_exist(): 
+            return False
+        return (other_numeric - self.value) > self.EPSILON 
+        
     @type_operator(FIELD_NUMERIC)
     def less_than_or_equal_to(self, other_numeric):
-        if self.exists(): 
-            return self.less_than(other_numeric) or self.equal_to(other_numeric)
-        return False 
-    
+        if self.does_not_exist(): 
+            return False 
+        return self.less_than(other_numeric) or self.equal_to(other_numeric)
+        
     @type_operator(FIELD_NO_INPUT)
-    def exists(self):
-        return self.value != None 
+    def does_not_exist(self):
+        return self.value == None 
 
 @export_type
 class BooleanType(BaseType):

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -141,6 +141,8 @@ class NumericType(BaseType):
 
     @staticmethod
     def _assert_valid_value_and_cast(value):
+        if value == None: 
+            return None 
         if isinstance(value, float):
             # In python 2.6, casting float to Decimal doesn't work
             return float_to_decimal(value)
@@ -154,28 +156,43 @@ class NumericType(BaseType):
 
     @type_operator(FIELD_NUMERIC)
     def equal_to(self, other_numeric):
-        return abs(self.value - other_numeric) <= self.EPSILON
+        if self.exists(): 
+            return abs(self.value - other_numeric) <= self.EPSILON
+        return False 
 
     @type_operator(FIELD_NUMERIC)
     def not_equal_to(self, other_numeric):
-        return abs(self.value - other_numeric) > self.EPSILON
+        if self.exists(): 
+            return abs(self.value - other_numeric) > self.EPSILON
+        return False
 
     @type_operator(FIELD_NUMERIC)
     def greater_than(self, other_numeric):
-        return (self.value - other_numeric) > self.EPSILON
+        if self.exists(): 
+            return (self.value - other_numeric) > self.EPSILON 
+        return False
 
     @type_operator(FIELD_NUMERIC)
     def greater_than_or_equal_to(self, other_numeric):
-        return self.greater_than(other_numeric) or self.equal_to(other_numeric)
+        if self.exists(): 
+            return self.greater_than(other_numeric) or self.equal_to(other_numeric) 
+        return False 
 
     @type_operator(FIELD_NUMERIC)
     def less_than(self, other_numeric):
-        return (other_numeric - self.value) > self.EPSILON
+        if not self.exists(): 
+            return (other_numeric - self.value) > self.EPSILON 
+        return False
 
     @type_operator(FIELD_NUMERIC)
     def less_than_or_equal_to(self, other_numeric):
-        return self.less_than(other_numeric) or self.equal_to(other_numeric)
-
+        if not self.exists(): 
+            return self.less_than(other_numeric) or self.equal_to(other_numeric)
+        return False 
+    
+    @type_operator(FIELD_NO_INPUT)
+    def exists(self):
+        return self.value != None 
 
 @export_type
 class BooleanType(BaseType):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -141,8 +141,8 @@ expected_variable_type_operators = {
                     {'input_type': 'none', 'label': 'Is True', 'name': 'is_true'}
                 ],
                 'numeric': [
+                    {'input_type': 'none', 'label': 'Does Not Exist', 'name': 'does_not_exist'},
                     {'input_type': 'numeric', 'label': 'Equal To', 'name': 'equal_to'},
-                    {'input_type': 'none', 'label': 'Exists', 'name': 'exists'},
                     {'input_type': 'numeric', 'label': 'Greater Than', 'name': 'greater_than'},
                     {'input_type': 'numeric', 'label': 'Greater Than Or Equal To', 'name': 'greater_than_or_equal_to'},
                     {'input_type': 'numeric', 'label': 'Less Than', 'name': 'less_than'},

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,7 +3,6 @@ from business_rules import export_rule_data
 from business_rules.actions import rule_action, BaseActions
 from business_rules.variables import BaseVariables, string_rule_variable, numeric_rule_variable, boolean_rule_variable
 from business_rules.fields import FIELD_TEXT, FIELD_NUMERIC, FIELD_SELECT
-from pprint import pprint 
 from unittest import TestCase
 
 class SomeVariables(BaseVariables):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,7 +3,7 @@ from business_rules import export_rule_data
 from business_rules.actions import rule_action, BaseActions
 from business_rules.variables import BaseVariables, string_rule_variable, numeric_rule_variable, boolean_rule_variable
 from business_rules.fields import FIELD_TEXT, FIELD_NUMERIC, FIELD_SELECT
-
+from pprint import pprint 
 from unittest import TestCase
 
 class SomeVariables(BaseVariables):
@@ -130,16 +130,20 @@ class IntegrationTests(TestCase):
                            "docs": None,
                            'field_type': 'boolean',
                            'options': []}])
+        
+        variable_type_operators = all_data.get("variable_type_operators")
+        self.assertEqual(variable_type_operators, expected_variable_type_operators)
 
-        self.assertEqual(
-            all_data.get("variable_type_operators"),
-            {
+
+
+expected_variable_type_operators = {
                 'boolean': [
                     {'input_type': 'none', 'label': 'Is False', 'name': 'is_false'},
                     {'input_type': 'none', 'label': 'Is True', 'name': 'is_true'}
                 ],
                 'numeric': [
                     {'input_type': 'numeric', 'label': 'Equal To', 'name': 'equal_to'},
+                    {'input_type': 'none', 'label': 'Exists', 'name': 'exists'},
                     {'input_type': 'numeric', 'label': 'Greater Than', 'name': 'greater_than'},
                     {'input_type': 'numeric', 'label': 'Greater Than Or Equal To', 'name': 'greater_than_or_equal_to'},
                     {'input_type': 'numeric', 'label': 'Less Than', 'name': 'less_than'},
@@ -177,5 +181,3 @@ class IntegrationTests(TestCase):
                     {'input_type': 'text', 'label': 'Starts With', 'name': 'starts_with'}
                 ]
             }
-        )
-

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -84,6 +84,11 @@ class NumericOperatorTests(TestCase):
         self.assertFalse(NumericType(10).equal_to(10.00001))
         self.assertFalse(NumericType(10).equal_to(11))
         self.assertFalse(NumericType(None).equal_to(10))
+    
+    def test_numeric_not_equal_to(self):
+        self.assertTrue(NumericType(1).not_equal_to(10))
+        self.assertTrue(NumericType(10.1).not_equal_to(10))
+        self.assertFalse(NumericType(None).not_equal_to(10))
 
 
     def test_other_value_not_numeric(self):

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -53,6 +53,9 @@ class NumericOperatorTests(TestCase):
         err_string = "foo is not a valid numeric type"
         with self.assertRaisesRegex(AssertionError, err_string):
             NumericType("foo")
+        
+        num = NumericType(None)
+        self.assertEqual(num.value, None )
 
     def test_numeric_type_validates_and_casts_decimal(self):
         ten_dec = Decimal(10)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -84,11 +84,13 @@ class NumericOperatorTests(TestCase):
         self.assertFalse(NumericType(10).equal_to(10.00001))
         self.assertFalse(NumericType(10).equal_to(11))
         self.assertFalse(NumericType(None).equal_to(10))
+        self.assertFalse(NumericType(None).equal_to(0))
     
     def test_numeric_not_equal_to(self):
         self.assertTrue(NumericType(1).not_equal_to(10))
         self.assertTrue(NumericType(10.1).not_equal_to(10))
         self.assertFalse(NumericType(None).not_equal_to(10))
+        self.assertFalse(NumericType(None).not_equal_to(0))
 
 
     def test_other_value_not_numeric(self):

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -80,6 +80,8 @@ class NumericOperatorTests(TestCase):
         self.assertTrue(NumericType(10).equal_to(Decimal('10.0')))
         self.assertFalse(NumericType(10).equal_to(10.00001))
         self.assertFalse(NumericType(10).equal_to(11))
+        self.assertFalse(NumericType(None).equal_to(10))
+
 
     def test_other_value_not_numeric(self):
         error_string = "10 is not a valid numeric type"
@@ -92,6 +94,7 @@ class NumericOperatorTests(TestCase):
         self.assertTrue(NumericType(10.1).greater_than(10))
         self.assertFalse(NumericType(10.000001).greater_than(10))
         self.assertTrue(NumericType(10.000002).greater_than(10))
+        self.assertFalse(NumericType(None).greater_than(10))
 
     def test_numeric_greater_than_or_equal_to(self):
         self.assertTrue(NumericType(10).greater_than_or_equal_to(1))
@@ -100,6 +103,7 @@ class NumericOperatorTests(TestCase):
         self.assertTrue(NumericType(10.000001).greater_than_or_equal_to(10))
         self.assertTrue(NumericType(10.000002).greater_than_or_equal_to(10))
         self.assertTrue(NumericType(10).greater_than_or_equal_to(10))
+        self.assertFalse(NumericType(None).greater_than_or_equal_to(10))
 
     def test_numeric_less_than(self):
         self.assertTrue(NumericType(1).less_than(10))
@@ -107,6 +111,8 @@ class NumericOperatorTests(TestCase):
         self.assertTrue(NumericType(10).less_than(10.1))
         self.assertFalse(NumericType(10).less_than(10.000001))
         self.assertTrue(NumericType(10).less_than(10.000002))
+        self.assertFalse(NumericType(None).less_than(10))
+
 
     def test_numeric_less_than_or_equal_to(self):
         self.assertTrue(NumericType(1).less_than_or_equal_to(10))
@@ -115,6 +121,11 @@ class NumericOperatorTests(TestCase):
         self.assertTrue(NumericType(10).less_than_or_equal_to(10.000001))
         self.assertTrue(NumericType(10).less_than_or_equal_to(10.000002))
         self.assertTrue(NumericType(10).less_than_or_equal_to(10))
+        self.assertFalse(NumericType(None).less_than_or_equal_to(10))
+    
+    def test_exists(self):
+        self.assertTrue(NumericType(1).exists())
+        self.assertFalse(NumericType(None).exists())
 
 
 class BooleanOperatorTests(TestCase):

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -133,9 +133,9 @@ class NumericOperatorTests(TestCase):
         self.assertTrue(NumericType(10).less_than_or_equal_to(10))
         self.assertFalse(NumericType(None).less_than_or_equal_to(10))
     
-    def test_exists(self):
-        self.assertTrue(NumericType(1).exists())
-        self.assertFalse(NumericType(None).exists())
+    def test_does_not_exist(self):
+        self.assertFalse(NumericType(1).does_not_exist())
+        self.assertTrue(NumericType(None).does_not_exist())
 
 
 class BooleanOperatorTests(TestCase):


### PR DESCRIPTION
- For several rule cases, we are required to differentiate between variable = 0 and variable = Null. Currently we do so by adding additional 'variable exists' boolean variable condition along with the condition for the numeric variables state itself. eg. deductible exists (boolean variable) and deductible (numeric variable) is less than 10.

- Since many of our numeric rules default to 0 when the value is null, this in itself is incorrect and will error in `any` conditions. Eg. When deductible doesn't exist, any(deductible exists, deductible < 10) = any(False, 0<10) = True. 

- As a solution to this, I am adding an `exists` operator to NumericType. Now, only one condition will be required for any check (we get rid of the need for an explicit `exists` check. 