### PR TITLE
[feat]: Add contains_any and contains_all operators for select type

### DIFF
--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -241,13 +241,15 @@ class SelectType(BaseType):
     
     @type_operator(FIELD_SELECT, assert_type_for_arguments=False)
     def contains_any(self, other_value):
-        if not self.value or not other_value:
+        if not other_value or len(other_value) == 0:
             return False
-        for val in self.value:
-            for other_val in other_value:
-                if self._case_insensitive_equal_to(val, other_val):
-                    return True
-        return False
+        if not self.value or len(self.value) == 0:
+            return False
+        
+        self_set = set([val.lower() if isinstance(val, string_types) else val for val in self.value])
+        other_set = set([val.lower() if isinstance(val, string_types) else val for val in other_value])
+        
+        return len(self_set.intersection(other_set)) > 0
     
     @type_operator(FIELD_SELECT, assert_type_for_arguments=False)
     def contains_all(self, other_value):
@@ -255,14 +257,11 @@ class SelectType(BaseType):
             return False
         if not self.value or len(self.value) == 0:
             return False
-        for other_val in other_value:
-            exists = False
-            for val in self.value:
-                if self._case_insensitive_equal_to(val, other_val):
-                    exists = True
-            if not exists:
-                return False
-        return True
+        
+        self_set = set([val.lower() if isinstance(val, string_types) else val for val in self.value])
+        other_set = set([val.lower() if isinstance(val, string_types) else val for val in other_value])
+        
+        return len(self_set.intersection(other_set)) == len(other_set)
 
     @type_operator(FIELD_SELECT, assert_type_for_arguments=False)
     def does_not_contain(self, other_value):

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -238,6 +238,26 @@ class SelectType(BaseType):
             if self._case_insensitive_equal_to(val, other_value):
                 return True
         return False
+    
+    @type_operator(FIELD_SELECT, assert_type_for_arguments=False)
+    def contains_any(self, other_value):
+        if not other_value or len(other_value) == 0:
+            return False
+        for val in self.value:
+            for other_val in other_value:
+                if self._case_insensitive_equal_to(val, other_val):
+                    return True
+        return False
+    
+    @type_operator(FIELD_SELECT, assert_type_for_arguments=False)
+    def contains_all(self, other_value):
+        if not self.value or len(self.value) == 0:
+            return False
+        for val in self.value:
+            for other_val in other_value:
+                if not self._case_insensitive_equal_to(val, other_val):
+                    return False
+        return True
 
     @type_operator(FIELD_SELECT, assert_type_for_arguments=False)
     def does_not_contain(self, other_value):

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -241,8 +241,6 @@ class SelectType(BaseType):
     
     @type_operator(FIELD_SELECT, assert_type_for_arguments=False)
     def contains_any(self, other_value):
-        if not self.value or len(self.value) == 0:
-            return False
         for val in self.value:
             for other_val in other_value:
                 if self._case_insensitive_equal_to(val, other_val):

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -255,10 +255,13 @@ class SelectType(BaseType):
             return False
         if not self.value or len(self.value) == 0:
             return False
-        for val in self.value:
-            for other_val in other_value:
-                if not self._case_insensitive_equal_to(val, other_val):
-                    return False
+        for other_val in other_value:
+            exists = False
+            for val in self.value:
+                if self._case_insensitive_equal_to(val, other_val):
+                    exists = True
+            if not exists:
+                return False
         return True
 
     @type_operator(FIELD_SELECT, assert_type_for_arguments=False)

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -241,6 +241,8 @@ class SelectType(BaseType):
     
     @type_operator(FIELD_SELECT, assert_type_for_arguments=False)
     def contains_any(self, other_value):
+        if not self.value or not other_value:
+            return False
         for val in self.value:
             for other_val in other_value:
                 if self._case_insensitive_equal_to(val, other_val):

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -241,7 +241,7 @@ class SelectType(BaseType):
     
     @type_operator(FIELD_SELECT, assert_type_for_arguments=False)
     def contains_any(self, other_value):
-        if not other_value or len(other_value) == 0:
+        if not self.value or len(self.value) == 0:
             return False
         for val in self.value:
             for other_val in other_value:
@@ -251,6 +251,8 @@ class SelectType(BaseType):
     
     @type_operator(FIELD_SELECT, assert_type_for_arguments=False)
     def contains_all(self, other_value):
+        if not other_value or len(other_value) == 0:
+            return False
         if not self.value or len(self.value) == 0:
             return False
         for val in self.value:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -151,6 +151,8 @@ expected_variable_type_operators = {
                 ],
                 'select': [
                     {'input_type': 'select', 'label': 'Contains', 'name': 'contains'},
+                    {'input_type': 'select', 'label': 'Contains All', 'name': 'contains_all'},
+                    {'input_type': 'select', 'label': 'Contains Any', 'name': 'contains_any'},
                     {'input_type': 'select', 'label': 'Does Not Contain', 'name': 'does_not_contain'}
                 ],
                 'select_multiple': [

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -167,6 +167,22 @@ class SelectOperatorTests(TestCase):
         self.assertFalse(SelectType([1, 2]).does_not_contain(2))
         self.assertFalse(SelectType([1, 2, "a"]).does_not_contain("A"))
 
+    def test_contains_all(self):
+        self.assertTrue(SelectType([1, 2]).contains_all([2]))
+        self.assertTrue(SelectType([1, 2, "a"]).contains_all(["A"]))
+        self.assertTrue(SelectType([1, 2]).contains_all([1, 2, 1]))
+        self.assertFalse(SelectType([1, 2]).contains_all([]))
+        self.assertFalse(SelectType([1, 2]).contains_all([3]))
+        self.assertFalse(SelectType([1, 2]).contains_all([1, 2, 3]))
+
+    def test_contains_any(self):
+        self.assertTrue(SelectType([1, 2]).contains_any([2]))
+        self.assertTrue(SelectType([1, 2, "a"]).contains_any(["A"]))
+        self.assertTrue(SelectType([1, 2]).contains_any([1, 2, 1]))
+        self.assertFalse(SelectType([1, 2]).contains_any([3]))
+        self.assertFalse(SelectType([]).contains_any([3]))
+        self.assertFalse(SelectType([1, 2]).contains_any([]))
+
 
 class SelectMultipleOperatorTests(TestCase):
 


### PR DESCRIPTION
Currently for `select_rule_variable`, the only operators available to us are `contains` or `does_not_contain`. Specifically for contains, this does not work when we are comparing 2 lists and we want to check for overlap. This pr adds `contains_any` and `contains_all` operators to check if the state contains any element of the inputted list (if exists) or if the state variable (if exists) contains all elements of the inputted list.