### PR TITLE
update run to return a tuple of (rule triggered, rule applied)

### DIFF
--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.1.1+athelas7'
+__version__ = '1.1.1+athelas8'
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/engine.py
+++ b/business_rules/engine.py
@@ -17,10 +17,17 @@ def run_all(rule_list,
 
 
 def run(rule, defined_variables, defined_actions):
-    """
-    Runs a single rule and returns a tuple of (rule_triggered, rule_applied).
-    rule_triggered is True if the rule conditions are met, False otherwise.
-    rule_applied is True if any action returns True or None (legacy), False otherwise.
+    """Runs a single rule and returns a tuple of (rule_triggered, rule_applied).
+
+    Args:
+        rule: Dict containing 'conditions' and 'actions'.
+        defined_variables: Variables object for condition evaluation.
+        defined_actions: Actions object for action execution.
+
+    Returns:
+        tuple: A tuple of (rule_triggered, rule_applied) where:
+            rule_triggered (bool): True if the rule conditions are met, False otherwise.
+            rule_applied (bool): True if any action returns True or None (legacy), False otherwise.
     """
     conditions, actions = rule['conditions'], rule['actions']
     rule_triggered = check_conditions_recursively(conditions, defined_variables)
@@ -149,3 +156,4 @@ def do_actions(actions, defined_actions):
             any_action_applied = True
     # Return True if any action was applied, False if all returned False
     return any_action_applied
+    


### PR DESCRIPTION
run() in engine.py returned True/False based on whether the rule triggered (eg. conditions were satisfied). This has led to table bloat in our applied rules tables (particularly claim submissions), as many rules may not actually change the claim (eg. rule action quits out early). Given this, it is difficult to determine which rules actually impacted our claims.

This change returns a tuple of booleans to indicate if the rule was triggered and if the rule was applied. The check for rule triggered remains the same. To check if a rule was applied, this will return true if any of the actions return True or None. If a rule action explicitly returns False, it is considered as not applied.

Changes will be made in Normandy for all engines that leverage the business_rules engine run. For now, to be compatible, this only consists of handling the parsing of the new tuple return type correctly. For the billing rule engine, we will update our rule actions to explicitly return True/False, and the new rule_applied return variable will be used to conditionally update the applied rules table. Other rule engines will have the flexibility to follow the same pattern.